### PR TITLE
Trying to add benchmarks but something is broken

### DIFF
--- a/time_test.go
+++ b/time_test.go
@@ -1,6 +1,7 @@
 package cstrftime
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -8,33 +9,80 @@ import (
 )
 
 func TestFormat(t *testing.T) {
-	tm := time.Date(2000, 2, 1, 12, 30, 0, 0, time.UTC)
+	tm := time.Date(2000, 2, 1, 16, 30, 22, 123456789, time.UTC)
 
-	t.Run("weekday as locale’s abbreviated name", func(t *testing.T) {
-		assert.Equal(t, "Tue", Format("%a", tm))
-	})
+	cases := []struct {
+		name, format, result string
+	}{
+		{"weekday as locale’s abbreviated name", "%a", "Tue"},
+		{"weekday as locale’s full name", "%A", "Tuesday"},
+		{"weekday as a decimal number", "%w", "2"},
+		{"day of the month as a zero-padded decimal number", "%d", "01"},
+		{"month as locale’s abbreviated name", "%b", "Feb"},
+		{"month as locale’s full name", "%B", "February"},
+		{"month as a zero-padded decimal number", "%m", "02"},
+		{"24 hour Hours", "%H", "16"},
+		{"12 hour Hours", "%I", "04"},
+		{"Minutes", "%M", "30"},
+		{"Seconds", "%S", "22"},
+		{"seconds with decimals", "%S.%f", "22.123456"},
+		{"american date", "%m/%d/%Y", "02/01/2000"},
+		{"proper date", "%Y/%m/%d", "2000/02/01"},
+		{"dashed date", "%Y-%m-%d", "2000-02-01"},
+	}
 
-	t.Run("weekday as locale’s full name", func(t *testing.T) {
-		assert.Equal(t, "Tuesday", Format("%A", tm))
-	})
+	for _, c := range cases {
+		c := c
 
-	t.Run("weekday as a decimal number", func(t *testing.T) {
-		assert.Equal(t, "2", Format("%w", tm))
-	})
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.result, Format(c.format, tm))
+		})
+	}
+}
 
-	t.Run("day of the month as a zero-padded decimal number", func(t *testing.T) {
-		assert.Equal(t, "01", Format("%d", tm))
-	})
+func BenchmarkFormat(b *testing.B) {
+	tm := time.Date(2000, time.February, 13, 16, 30, 20, 12345, time.UTC)
 
-	t.Run("month as locale’s abbreviated name", func(t *testing.T) {
-		assert.Equal(t, "Feb", Format("%b", tm))
-	})
+	cases := []struct {
+		name, cFormat, goFormat string
+	}{
+		{"year", "%Y", "2006"},
+		{"date", "%Y/%m/%d", "2006/01/02"},
+	}
 
-	t.Run("month as locale’s full name", func(t *testing.T) {
-		assert.Equal(t, "February", Format("%B", tm))
-	})
+	for _, c := range cases {
+		assert.Equal(b, tm.Format(c.goFormat), Format(c.cFormat, tm), c.name)
+	}
 
-	t.Run("month as a zero-padded decimal number", func(t *testing.T) {
-		assert.Equal(t, "02", Format("%m", tm))
-	})
+	for _, c := range cases {
+		for _, native := range []bool{true, false} {
+			c := c
+			native := native
+
+			b.Run(fmt.Sprintf("%s - native(%t)", c.name, native), func(b *testing.B) {
+				var (
+					want = tm.Format(c.goFormat)
+					got  string
+				)
+
+				switch native {
+				case true:
+					b.ResetTimer()
+					for i := 0; i < b.N; i++ {
+						if got = tm.Format(c.goFormat); want != got {
+							b.Fatalf("want: %q got: %q", want, got)
+						}
+					}
+
+				case false:
+					b.ResetTimer()
+					for i := 0; i < b.N; i++ {
+						if got = Format(c.cFormat, tm); want != got {
+							b.Fatalf("want: %q got: %q", want, got)
+						}
+					}
+				}
+			})
+		}
+	}
 }


### PR DESCRIPTION
Time doesn't get formatted correctly, decimal seconds disappear, and
something about the benchmarks results in null characters for the day of
the month in the benchmarks.

The one benchmark that does work so far shows a pretty hefty performance hit:

```
go test -bench . -benchmem -run XXX
goos: darwin
goarch: amd64
pkg: github.com/apiarian/cstrftime
BenchmarkFormat/year_-_native(true)-4           20000000                95.5 ns/op             4 B/op          1 allocs/op
BenchmarkFormat/year_-_native(false)-4            500000              2486 ns/op              16 B/op          3 allocs/op
```